### PR TITLE
SSH hostkeys removed from build stage

### DIFF
--- a/dockerfiles/base/Dockerfile.rhel9.2
+++ b/dockerfiles/base/Dockerfile.rhel9.2
@@ -124,16 +124,20 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python3.10 -m pip install habana_media_loader=="${VERSION}"."${REVISION}"
 
+# SSH Configuration for setting up host keys at runtime
+COPY generate_ssh_keys.sh /root/generate_ssh_keys.sh
+
 # SSH configuration necessary to support mpi-operator v2
 RUN mkdir -p /var/run/sshd && \
     sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
     sed -i 's/#\(ForwardAgent \).*/\1yes/g' /etc/ssh/ssh_config && \
     echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
     sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
-    ssh-keygen -A && \
+    echo "/root/generate_ssh_keys.sh" >> ~/.bashrc && \
     mkdir -p /var/run/sshd && echo "/usr/sbin/sshd -p 3022" | tee -a ~/.bashrc
 
 ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
 ENV HABANA_LOGS=/var/log/habana_logs/
 ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
 ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
+

--- a/dockerfiles/base/generate_ssh_keys.sh
+++ b/dockerfiles/base/generate_ssh_keys.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+function gen_single_key() {
+	ALG_NAME=$1
+	if [[ ! -f /etc/ssh/ssh_host_${ALG_NAME}_key ]]; then
+		ssh-keygen -q -N "" -t "${ALG_NAME}" -f "/etc/ssh/ssh_host_${ALG_NAME}_key"
+	fi
+}
+
+gen_single_key dsa
+gen_single_key rsa
+gen_single_key ecdsa
+gen_single_key ed25519


### PR DESCRIPTION
This PR removes the generation of SSH Private Host Keys from the containers.

To generate the keys at runtime you can simply add this env variable while starting the container and it should work. If you're working with bash in interactive mode then you don't need to perform this step.

`BASH_ENV=/root/generate_ssh_keys`