### PR TITLE
Add 2 new OpenShift AI workbench container files

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -23,16 +23,17 @@ This folder contains Gaudi dockerfiles and makefiles that can be used to build H
 
 ## Support Matrix
 
-| BUILD_OS              | Internal torch | Upstream torch | Custom python |
-|-----------------------|:--------------:|:--------------:|:-------------:|
-| ubuntu22.04           |       Yes      |       Yes      |      3.11     |
-| ubuntu24.04           |       Yes      |                |               |
-| rhel9.4               |       Yes      |       Yes      |      3.12     |
-| rhel9.6               |       Yes      |                |               |
-| rhel9.6.rhoai.pytorch |       Yes      |                |               |
-| tencentos3.1          |       Yes      |                |               |
-| opencloudos9.2        |       Yes      |                |               |
-| navix9.4              |       Yes      |                |               |
+| BUILD_OS                  | Internal torch | Upstream torch | Custom python |
+|---------------------------|:--------------:|:--------------:|:-------------:|
+| ubuntu22.04               |       Yes      |       Yes      |      3.11     |
+| ubuntu24.04               |       Yes      |                |               |
+| rhel9.4                   |       Yes      |       Yes      |      3.12     |
+| rhel9.6                   |       Yes      |                |               |
+| rhel9.6.rhoai.pytorch     |       Yes      |                |               |
+| rhel9.6.rhoai.datascience |       Yes      |                |               |
+| tencentos3.1              |       Yes      |                |               |
+| opencloudos9.2            |       Yes      |                |               |
+| navix9.4                  |       Yes      |                |               |
 
 <br/>
 You can also build triton-installer, which is based on ubuntu22.04 OS

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -23,15 +23,16 @@ This folder contains Gaudi dockerfiles and makefiles that can be used to build H
 
 ## Support Matrix
 
-| BUILD_OS       | Internal torch | Upstream torch | Custom python |
-|----------------|:--------------:|:--------------:|:-------------:|
-| ubuntu22.04    |       Yes      |       Yes      |      3.11     |
-| ubuntu24.04    |       Yes      |                |               |
-| rhel9.4        |       Yes      |       Yes      |      3.12     |
-| rhel9.6        |       Yes      |                |               |
-| tencentos3.1   |       Yes      |                |               |
-| opencloudos9.2 |       Yes      |                |               |
-| navix9.4       |       Yes      |                |               |
+| BUILD_OS              | Internal torch | Upstream torch | Custom python |
+|-----------------------|:--------------:|:--------------:|:-------------:|
+| ubuntu22.04           |       Yes      |       Yes      |      3.11     |
+| ubuntu24.04           |       Yes      |                |               |
+| rhel9.4               |       Yes      |       Yes      |      3.12     |
+| rhel9.6               |       Yes      |                |               |
+| rhel9.6.rhoai.pytorch |       Yes      |                |               |
+| tencentos3.1          |       Yes      |                |               |
+| opencloudos9.2        |       Yes      |                |               |
+| navix9.4              |       Yes      |                |               |
 
 <br/>
 You can also build triton-installer, which is based on ubuntu22.04 OS

--- a/dockerfiles/base/Dockerfile.rhel9.6.rhoai.datascience
+++ b/dockerfiles/base/Dockerfile.rhel9.6.rhoai.datascience
@@ -137,11 +137,6 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python3 -m pip install habana_media_loader=="${VERSION}"."${REVISION}"
 
-ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
-ENV HABANA_LOGS=/var/log/habana_logs/
-ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
-ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
-
 # SSH configuration necessary to support mpi-operator v2
 RUN mkdir -p /var/run/sshd && \
     sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
@@ -150,6 +145,11 @@ RUN mkdir -p /var/run/sshd && \
     sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
     mkdir -p /var/run/sshd && echo "/usr/sbin/sshd -p 3022" | tee -a ~/.bashrc && \
     chown -R 1001:0 /opt/app-root/src
+
+ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
+ENV HABANA_LOGS=/var/log/habana_logs/
+ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
+ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
 
 WORKDIR /opt/app-root/src
 USER 1001

--- a/dockerfiles/base/Dockerfile.rhel9.6.rhoai.datascience
+++ b/dockerfiles/base/Dockerfile.rhel9.6.rhoai.datascience
@@ -1,0 +1,155 @@
+# Copyright (c) 2025 Habana Labs, Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# HabanaLabs Dockerfile base installer layer for RedHat 9.6 dedicated for OpenShift
+FROM quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.12-pr-2113
+ARG ARTIFACTORY_URL
+ARG VERSION
+ARG REVISION
+
+# for RHEL certification
+LABEL vendor="Habanalabs Ltd."
+LABEL release="${VERSION}-${REVISION}"
+
+COPY LICENSE /licenses/
+
+USER 0
+
+RUN dnf install -y python3-dnf-plugin-versionlock redhat-release containers-common && \
+    dnf clean all
+
+RUN rpm -e --nodeps openssl-fips-provider-so
+
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf clean all
+
+RUN echo "[BaseOS]" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "name=CentOS Linux 9 - BaseOS" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
+
+RUN echo "[centos9]" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "name=CentOS Linux 9 - AppStream" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "baseurl=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo
+
+RUN echo "[CRB]" > /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "name=CentOS Linux 9 - CRB" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "baseurl=https://mirror.stream.centos.org/9-stream/CRB/x86_64/os" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo
+
+RUN dnf install -y \
+        bzip2 \
+        bzip2-devel \
+        clang \
+        cmake3 \
+        cpp \
+        ffmpeg-free \
+        gcc \
+        gcc-c++ \
+        git \
+        glibc \
+        glibc-devel \
+        glibc-headers \
+        iproute \
+        jemalloc \
+        libarchive \
+        libffi-devel \
+        libjpeg-devel \
+        libksba \
+        llvm \
+        lsb_release \
+        lsof \
+        mesa-libGL \
+        openssh-clients \
+        openssh-server \
+        openssl \
+        openssl-devel \
+        perl-Net-SSLeay \
+        python3-devel \
+        python3.12 \
+        python3.12-devel \
+        unzip \
+        wget \
+        zlib-devel && \
+    dnf clean all && \
+    rm -f /etc/ssh/ssh_host_*_key*
+
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && \
+    alternatives --set python3 /usr/bin/python3.12
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_NO_CACHE_DIR=on
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    rm -f get-pip.py && \
+    python3 -m pip install setuptools==79.0.1 wheel && \
+    python3 -m pip install --upgrade Jinja2 protobuf urllib3 requests
+
+COPY install_efa.sh .
+RUN ./install_efa.sh && rm install_efa.sh && rm -rf /etc/ld.so.conf.d/efa.conf /etc/profile.d/efa.sh
+
+ENV OPENMPI_VERSION=4.1.6
+ENV MPI_ROOT=/opt/habanalabs/openmpi
+ENV LD_LIBRARY_PATH=${MPI_ROOT}/lib:/usr/lib/habanalabs:$LD_LIBRARY_PATH
+ENV PATH=${MPI_ROOT}/bin:$PATH
+ENV OPAL_PREFIX=${MPI_ROOT}
+ENV MPICC=${MPI_ROOT}/bin/mpicc
+ENV RDMAV_FORK_SAFE=1
+ENV FI_EFA_USE_DEVICE_RDMA=0
+ENV OMPI_MCA_btl=^openib
+
+RUN echo "[habanalabs]" > /etc/yum.repos.d/habanalabs.repo && \
+    echo "name=Habana RH9 Linux repo" >> /etc/yum.repos.d/habanalabs.repo && \
+    echo "baseurl=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6" >> /etc/yum.repos.d/habanalabs.repo && \
+    echo "gpgkey=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6/repodata/repomd.xml.key" >> /etc/yum.repos.d/habanalabs.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/habanalabs.repo
+
+RUN _GPG_TEMP=$(mktemp -d) && \
+    wget -q -O "${_GPG_TEMP}/habana_pubkey" "https://${ARTIFACTORY_URL}/artifactory/gaudi-general/keyPairs/primary/public" && rpm --import "${_GPG_TEMP}/habana_pubkey" && \
+    rm -rf "${_GPG_TEMP}"
+
+RUN dnf install -y \
+        habanalabs-rdma-core-"$VERSION"-"$REVISION".el9 \
+        habanalabs-thunk-"$VERSION"-"$REVISION".el9 \
+        habanalabs-firmware-tools-"$VERSION"-"$REVISION".el9 \
+        habanalabs-graph-"$VERSION"-"$REVISION".el9 && \
+    dnf clean all && \
+    chmod +t /var/log/habana_logs && \
+    rm -f /etc/yum.repos.d/habanalabs.repo
+
+ENV RDMA_CORE_ROOT=/opt/habanalabs/rdma-core/src
+ENV RDMA_CORE_LIB=${RDMA_CORE_ROOT}/build/lib
+
+RUN wget -q -O /tmp/openmpi-${OPENMPI_VERSION}.tar.gz https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz && \
+    tar -xzf /tmp/openmpi-${OPENMPI_VERSION}.tar.gz -C /tmp && \
+    cd /tmp/openmpi-${OPENMPI_VERSION} && \
+    ./configure --prefix=${MPI_ROOT} --with-verbs && \
+    make -j$(nproc) && make install && cd / && rm -rf /tmp/openmpi-${OPENMPI_VERSION}.tar.gz /tmp/openmpi-${OPENMPI_VERSION}
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN python3 -m pip install habana_media_loader=="${VERSION}"."${REVISION}"
+
+ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
+ENV HABANA_LOGS=/var/log/habana_logs/
+ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
+ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
+
+# SSH configuration necessary to support mpi-operator v2
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    sed -i 's/#\(ForwardAgent \).*/\1yes/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    mkdir -p /var/run/sshd && echo "/usr/sbin/sshd -p 3022" | tee -a ~/.bashrc && \
+    chown -R 1001:0 /opt/app-root/src
+
+WORKDIR /opt/app-root/src
+USER 1001

--- a/dockerfiles/base/Dockerfile.rhel9.6.rhoai.pytorch
+++ b/dockerfiles/base/Dockerfile.rhel9.6.rhoai.pytorch
@@ -137,11 +137,6 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python3 -m pip install habana_media_loader=="${VERSION}"."${REVISION}"
 
-ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
-ENV HABANA_LOGS=/var/log/habana_logs/
-ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
-ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
-
 # SSH configuration necessary to support mpi-operator v2
 RUN mkdir -p /var/run/sshd && \
     sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
@@ -150,6 +145,11 @@ RUN mkdir -p /var/run/sshd && \
     sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
     mkdir -p /var/run/sshd && echo "/usr/sbin/sshd -p 3022" | tee -a ~/.bashrc && \
     chown -R 1001:0 /opt/app-root/src
+
+ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
+ENV HABANA_LOGS=/var/log/habana_logs/
+ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
+ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
 
 WORKDIR /opt/app-root/src
 USER 1001

--- a/dockerfiles/base/Dockerfile.rhel9.6.rhoai.pytorch
+++ b/dockerfiles/base/Dockerfile.rhel9.6.rhoai.pytorch
@@ -1,0 +1,155 @@
+# Copyright (c) 2025 Habana Labs, Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# HabanaLabs Dockerfile base installer layer for RedHat 9.6 dedicated for OpenShift
+FROM quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.12-pr-2113
+ARG ARTIFACTORY_URL
+ARG VERSION
+ARG REVISION
+
+# for RHEL certification
+LABEL vendor="Habanalabs Ltd."
+LABEL release="${VERSION}-${REVISION}"
+
+COPY LICENSE /licenses/
+
+USER 0
+
+RUN dnf install -y python3-dnf-plugin-versionlock redhat-release containers-common && \
+    dnf clean all
+
+RUN rpm -e --nodeps openssl-fips-provider-so
+
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf clean all
+
+RUN echo "[BaseOS]" > /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "name=CentOS Linux 9 - BaseOS" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/CentOS-Linux-BaseOS.repo
+
+RUN echo "[centos9]" > /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "name=CentOS Linux 9 - AppStream" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "baseurl=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/CentOS-Linux-AppStream.repo
+
+RUN echo "[CRB]" > /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "name=CentOS Linux 9 - CRB" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "baseurl=https://mirror.stream.centos.org/9-stream/CRB/x86_64/os" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/CentOS-Linux-CRB.repo
+
+RUN dnf install -y \
+        bzip2 \
+        bzip2-devel \
+        clang \
+        cmake3 \
+        cpp \
+        ffmpeg-free \
+        gcc \
+        gcc-c++ \
+        git \
+        glibc \
+        glibc-devel \
+        glibc-headers \
+        iproute \
+        jemalloc \
+        libarchive \
+        libffi-devel \
+        libjpeg-devel \
+        libksba \
+        llvm \
+        lsb_release \
+        lsof \
+        mesa-libGL \
+        openssh-clients \
+        openssh-server \
+        openssl \
+        openssl-devel \
+        perl-Net-SSLeay \
+        python3-devel \
+        python3.12 \
+        python3.12-devel \
+        unzip \
+        wget \
+        zlib-devel && \
+    dnf clean all && \
+    rm -f /etc/ssh/ssh_host_*_key*
+
+RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 && \
+    alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && \
+    alternatives --set python3 /usr/bin/python3.12
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_NO_CACHE_DIR=on
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    rm -f get-pip.py && \
+    python3 -m pip install setuptools==79.0.1 wheel && \
+    python3 -m pip install --upgrade Jinja2 protobuf urllib3 requests
+
+COPY install_efa.sh .
+RUN ./install_efa.sh && rm install_efa.sh && rm -rf /etc/ld.so.conf.d/efa.conf /etc/profile.d/efa.sh
+
+ENV OPENMPI_VERSION=4.1.6
+ENV MPI_ROOT=/opt/habanalabs/openmpi
+ENV LD_LIBRARY_PATH=${MPI_ROOT}/lib:/usr/lib/habanalabs:$LD_LIBRARY_PATH
+ENV PATH=${MPI_ROOT}/bin:$PATH
+ENV OPAL_PREFIX=${MPI_ROOT}
+ENV MPICC=${MPI_ROOT}/bin/mpicc
+ENV RDMAV_FORK_SAFE=1
+ENV FI_EFA_USE_DEVICE_RDMA=0
+ENV OMPI_MCA_btl=^openib
+
+RUN echo "[habanalabs]" > /etc/yum.repos.d/habanalabs.repo && \
+    echo "name=Habana RH9 Linux repo" >> /etc/yum.repos.d/habanalabs.repo && \
+    echo "baseurl=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6" >> /etc/yum.repos.d/habanalabs.repo && \
+    echo "gpgkey=https://${ARTIFACTORY_URL}/artifactory/rhel/9/9.6/repodata/repomd.xml.key" >> /etc/yum.repos.d/habanalabs.repo && \
+    echo "gpgcheck=1" >> /etc/yum.repos.d/habanalabs.repo
+
+RUN _GPG_TEMP=$(mktemp -d) && \
+    wget -q -O "${_GPG_TEMP}/habana_pubkey" "https://${ARTIFACTORY_URL}/artifactory/gaudi-general/keyPairs/primary/public" && rpm --import "${_GPG_TEMP}/habana_pubkey" && \
+    rm -rf "${_GPG_TEMP}"
+
+RUN dnf install -y \
+        habanalabs-rdma-core-"$VERSION"-"$REVISION".el9 \
+        habanalabs-thunk-"$VERSION"-"$REVISION".el9 \
+        habanalabs-firmware-tools-"$VERSION"-"$REVISION".el9 \
+        habanalabs-graph-"$VERSION"-"$REVISION".el9 && \
+    dnf clean all && \
+    chmod +t /var/log/habana_logs && \
+    rm -f /etc/yum.repos.d/habanalabs.repo
+
+ENV RDMA_CORE_ROOT=/opt/habanalabs/rdma-core/src
+ENV RDMA_CORE_LIB=${RDMA_CORE_ROOT}/build/lib
+
+RUN wget -q -O /tmp/openmpi-${OPENMPI_VERSION}.tar.gz https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPENMPI_VERSION}.tar.gz && \
+    tar -xzf /tmp/openmpi-${OPENMPI_VERSION}.tar.gz -C /tmp && \
+    cd /tmp/openmpi-${OPENMPI_VERSION} && \
+    ./configure --prefix=${MPI_ROOT} --with-verbs && \
+    make -j$(nproc) && make install && cd / && rm -rf /tmp/openmpi-${OPENMPI_VERSION}.tar.gz /tmp/openmpi-${OPENMPI_VERSION}
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN python3 -m pip install habana_media_loader=="${VERSION}"."${REVISION}"
+
+ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
+ENV HABANA_LOGS=/var/log/habana_logs/
+ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
+ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
+
+# SSH configuration necessary to support mpi-operator v2
+RUN mkdir -p /var/run/sshd && \
+    sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    sed -i 's/#\(ForwardAgent \).*/\1yes/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    mkdir -p /var/run/sshd && echo "/usr/sbin/sshd -p 3022" | tee -a ~/.bashrc && \
+    chown -R 1001:0 /opt/app-root/src
+
+WORKDIR /opt/app-root/src
+USER 1001

--- a/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.datascience
+++ b/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.datascience
@@ -34,14 +34,15 @@ RUN dnf install --nodocs --setopt=install_weak_deps=false --allowerasing -y \
     dnf clean all
 
 COPY install_packages.sh .
+
 RUN ./install_packages.sh && rm -f install_packages.sh && \
     /sbin/ldconfig
-
-USER 1001
-RUN echo "source /etc/profile.d/habanalabs.sh" >> ~/.bashrc
 
 # Set LD_PRELOAD after all required installations to
 # avoid warnings during docker creation
 ENV LD_PRELOAD=/usr/lib64/libtcmalloc.so.4
 ENV TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=7516192768
+
+USER 1001
+RUN echo "source /etc/profile.d/habanalabs.sh" >> ~/.bashrc
 WORKDIR /opt/app-root/src

--- a/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.datascience
+++ b/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.datascience
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 HabanaLabs, Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# HabanaLabs Dockerfile PyTorch installer layer for RHEL 9.6
+ARG BASE_NAME
+ARG VERSION
+ARG REVISION
+FROM ${BASE_NAME}:${VERSION}-${REVISION}
+ARG PT_VERSION
+ARG VERSION
+ARG REVISION
+ARG BASE_NAME
+ARG ARTIFACTORY_URL
+ARG TORCH_TYPE
+
+LABEL name="PyTorch Installer for OpenShift Workbenches"
+LABEL summary="Habanalabs PyTorch installer layer for RHEL9.6 dedicated for OpenShift Workbenches"
+LABEL description="Image with pre installed Habanalabs packages for PyTorch dedicated for OpenShift Workbenches"
+
+RUN echo "/usr/lib/habanalabs" > $(python3 -c "import sysconfig; print(sysconfig.get_path('platlib'))")/habanalabs-graph.pth
+
+USER 0
+
+RUN dnf install --nodocs --setopt=install_weak_deps=false --allowerasing -y \
+        cairo-devel \
+        gperftools-devel \
+        jq \
+        lapack-devel \
+        numactl \
+        numactl-devel \
+        openblas-devel \
+        which && \
+    dnf clean all
+
+COPY install_packages.sh .
+RUN ./install_packages.sh && rm -f install_packages.sh && \
+    /sbin/ldconfig
+
+USER 1001
+RUN echo "source /etc/profile.d/habanalabs.sh" >> ~/.bashrc
+
+# Set LD_PRELOAD after all required installations to
+# avoid warnings during docker creation
+ENV LD_PRELOAD=/usr/lib64/libtcmalloc.so.4
+ENV TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=7516192768
+WORKDIR /opt/app-root/src

--- a/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.pytorch
+++ b/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.pytorch
@@ -34,14 +34,15 @@ RUN dnf install --nodocs --setopt=install_weak_deps=false --allowerasing -y \
     dnf clean all
 
 COPY install_packages.sh .
+
 RUN ./install_packages.sh && rm -f install_packages.sh && \
     /sbin/ldconfig
-
-USER 1001
-RUN echo "source /etc/profile.d/habanalabs.sh" >> ~/.bashrc
 
 # Set LD_PRELOAD after all required installations to
 # avoid warnings during docker creation
 ENV LD_PRELOAD=/usr/lib64/libtcmalloc.so.4
 ENV TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=7516192768
+
+USER 1001
+RUN echo "source /etc/profile.d/habanalabs.sh" >> ~/.bashrc
 WORKDIR /opt/app-root/src

--- a/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.pytorch
+++ b/dockerfiles/pytorch/Dockerfile.rhel9.6.rhoai.pytorch
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 HabanaLabs, Ltd.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# HabanaLabs Dockerfile PyTorch installer layer for RHEL 9.6
+ARG BASE_NAME
+ARG VERSION
+ARG REVISION
+FROM ${BASE_NAME}:${VERSION}-${REVISION}
+ARG PT_VERSION
+ARG VERSION
+ARG REVISION
+ARG BASE_NAME
+ARG ARTIFACTORY_URL
+ARG TORCH_TYPE
+
+LABEL name="PyTorch Installer for OpenShift Workbenches"
+LABEL summary="Habanalabs PyTorch installer layer for RHEL9.6 dedicated for OpenShift Workbenches"
+LABEL description="Image with pre installed Habanalabs packages for PyTorch dedicated for OpenShift Workbenches"
+
+RUN echo "/usr/lib/habanalabs" > $(python3 -c "import sysconfig; print(sysconfig.get_path('platlib'))")/habanalabs-graph.pth
+
+USER 0
+
+RUN dnf install --nodocs --setopt=install_weak_deps=false --allowerasing -y \
+        cairo-devel \
+        gperftools-devel \
+        jq \
+        lapack-devel \
+        numactl \
+        numactl-devel \
+        openblas-devel \
+        which && \
+    dnf clean all
+
+COPY install_packages.sh .
+RUN ./install_packages.sh && rm -f install_packages.sh && \
+    /sbin/ldconfig
+
+USER 1001
+RUN echo "source /etc/profile.d/habanalabs.sh" >> ~/.bashrc
+
+# Set LD_PRELOAD after all required installations to
+# avoid warnings during docker creation
+ENV LD_PRELOAD=/usr/lib64/libtcmalloc.so.4
+ENV TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=7516192768
+WORKDIR /opt/app-root/src


### PR DESCRIPTION
- This PR adds 2 new Container Images that can be used as workbenches in OpenShift AI.
  - `pytorch-installer-rhel9.6.rhoai.datascience-2.7.1:1.22.1-6`
  - `pytorch-installer-rhel9.6.rhoai.pytorch-2.7.1:1.22.1-6`
- Container files are based on workbench images provided by opendatahub.io
  - Red Hat Universal Base Image 9 (v9.6)
- They enable easy and fast work with Gaudi on OpenShift Cluster via Jupyter Notebook in browser
- Communication with Gaudi through Intel Gaudi Operator
- Build process is the same as for rest of the containers in the repository
- They are meant to be used by customers and developers wanting to start working with Intel Gaudi Accelerators on OpenShift AI
  - Instructions on how to use it will be published on https://github.com/rh-ai-quickstart/custom-workbench-images-examples